### PR TITLE
Fix check for text property in user message content output

### DIFF
--- a/src/Resources/views/data_collector.html.twig
+++ b/src/Resources/views/data_collector.html.twig
@@ -107,7 +107,7 @@
                                                             {{ message.content|nl2br }}
                                                         {% elseif 'user' == message.role.value %}
                                                             {% for item in message.content %}
-                                                                {% if item.text %}
+                                                                {% if item.text is defined %}
                                                                     {{ item.text|nl2br }}
                                                                 {% else %}
                                                                     <img src="{{ item.url }}" />


### PR DESCRIPTION
Just a small fix. Without the `is defined` twig is throwing an exception it cannot access a text property. Which is correct in fact but can be catched. 