### PR TITLE
Allo php-llm/llm-chain 0.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "php-llm/llm-chain": "^0.9.3",
+        "php-llm/llm-chain": "^0.9.3 || ^0.10.0",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
         "symfony/framework-bundle": "^6.4 || ^7.0"


### PR DESCRIPTION
```
  Problem 1
    - Root composer.json requires php-llm/llm-chain ^0.10, found php-llm/llm-chain[0.10.0] but these were not loaded, likely because it conflicts with another require.
  Problem 2
    - php-llm/llm-chain-bundle is locked to version 0.9.1 and an update of this package was not requested.
    - php-llm/llm-chain-bundle 0.9.1 requires php-llm/llm-chain ^0.9.3 -> found php-llm/llm-chain[0.9.3] but it conflicts with your root composer.json require (^0.10).
```