### PR TITLE
fix: consolidate tool config and make it work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ llm_chain:
             platform: 'llm_chain.platform.anthropic'
             model:
                 name: 'Claude'
-            tools: # If undefined, all tools are injected into the chain, use "[]" or "false" to have no tools.
+            tools: # If undefined, all tools are injected into the chain, use "tools: false" to disable tools.
                 - 'PhpLlm\LlmChain\Chain\ToolBox\Tool\Wikipedia'
     store:
         # also azure_search, mongodb and pinecone are supported as store type
@@ -127,6 +127,25 @@ final class CompanyName
         return 'ACME Corp.'
     }
 }
+```
+
+The chain configuration by default will inject all known tools into the chain.
+
+To disable this behavior, set the `tools` option to `false`:
+```yaml
+llm_chain:
+    chain:
+        my_chain:
+            tools: false
+```
+
+To inject only specific tools, list them in the configuration:
+```yaml
+llm_chain:
+    chain:
+        my_chain:
+            tools:
+                - 'PhpLlm\LlmChain\Chain\ToolBox\Tool\SimilaritySearch'
 ```
 
 ### Profiler

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -65,11 +65,25 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->booleanNode('structured_output')->defaultTrue()->end()
                             ->arrayNode('tools')
+                                ->addDefaultsIfNotSet()
+                                ->treatFalseLike(['enabled' => false])
+                                ->treatTrueLike(['enabled' => true])
+                                ->treatNullLike(['enabled' => true])
                                 ->beforeNormalization()
-                                    ->ifTrue(fn ($v) => false === $v)
-                                    ->then(fn () => [])
+                                    ->ifArray()
+                                    ->then(function (array $v) {
+                                        return [
+                                            'enabled' => $v['enabled'] ?? true,
+                                            'services' => $v['services'] ?? $v,
+                                        ];
+                                    })
                                 ->end()
-                                ->scalarPrototype()->end()
+                                ->children()
+                                    ->booleanNode('enabled')->defaultTrue()->end()
+                                    ->arrayNode('services')
+                                        ->scalarPrototype()->end()
+                                    ->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()


### PR DESCRIPTION
now three ways are possible:

* **Don't configure it** => default is all tools are registered in the chain
* **Configure tools** => only those are registered in the chain
  ```yaml
  llm_chain:
    chain:
        my_chain:
            tools:
                - 'PhpLlm\LlmChain\Chain\ToolBox\Tool\SimilaritySearch'
  ``` 
* **Disable tools** => no tools are registered at all in the chain
  ```yaml
  llm_chain:
    chain:
        my_chain:
            tools: false
  ```

was a bit tricky and is heavily inspired by the `canBeDisabled()` thingy with creating a substructure that could also be used:

```yaml
llm_chain:
    chain:
        my_chain:
            tools:
                enabled: true
                services:
                    - 'PhpLlm\LlmChain\Chain\ToolBox\Tool\SimilaritySearch'
```