### PR TITLE
chore: support LLM Chain 0.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,3 @@ ci-lowest: deps-low rector cs phpstan tests
 
 ci-dev: deps-dev rector cs phpstan tests
 	git restore composer.json
-
-coverage:
-	XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html=coverage

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "php-llm/llm-chain": "^0.21",
+        "php-llm/llm-chain": "^0.22",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",
         "symfony/framework-bundle": "^6.4 || ^7.0",

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChainBundle\DependencyInjection;
 
-use PhpLlm\LlmChain\PlatformInterface;
+use PhpLlm\LlmChain\Platform\PlatformInterface;
 use PhpLlm\LlmChain\Store\StoreInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/src/Profiler/DataCollector.php
+++ b/src/Profiler/DataCollector.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChainBundle\Profiler;
 
-use PhpLlm\LlmChain\Chain\Toolbox\Metadata;
 use PhpLlm\LlmChain\Chain\Toolbox\ToolboxInterface;
+use PhpLlm\LlmChain\Platform\Tool\Tool;
 use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
 use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
 use Symfony\Component\HttpFoundation\Request;
@@ -45,7 +45,7 @@ final class DataCollector extends AbstractDataCollector
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         $this->data = [
-            'tools' => $this->defaultToolBox->getMap(),
+            'tools' => $this->defaultToolBox->getTools(),
             'platform_calls' => array_merge(...array_map(fn (TraceablePlatform $platform) => $platform->calls, $this->platforms)),
             'tool_calls' => array_merge(...array_map(fn (TraceableToolbox $toolbox) => $toolbox->calls, $this->toolboxes)),
         ];
@@ -65,7 +65,7 @@ final class DataCollector extends AbstractDataCollector
     }
 
     /**
-     * @return Metadata[]
+     * @return Tool[]
      */
     public function getTools(): array
     {

--- a/src/Profiler/TraceablePlatform.php
+++ b/src/Profiler/TraceablePlatform.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChainBundle\Profiler;
 
-use PhpLlm\LlmChain\Model\Message\Content\File;
-use PhpLlm\LlmChain\Model\Model;
-use PhpLlm\LlmChain\Model\Response\AsyncResponse;
-use PhpLlm\LlmChain\Model\Response\ResponseInterface;
-use PhpLlm\LlmChain\PlatformInterface;
+use PhpLlm\LlmChain\Platform\Message\Content\File;
+use PhpLlm\LlmChain\Platform\Model;
+use PhpLlm\LlmChain\Platform\PlatformInterface;
+use PhpLlm\LlmChain\Platform\Response\AsyncResponse;
+use PhpLlm\LlmChain\Platform\Response\ResponseInterface;
 
 /**
  * @phpstan-type PlatformCallData array{

--- a/src/Profiler/TraceableToolbox.php
+++ b/src/Profiler/TraceableToolbox.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpLlm\LlmChainBundle\Profiler;
 
 use PhpLlm\LlmChain\Chain\Toolbox\ToolboxInterface;
-use PhpLlm\LlmChain\Model\Response\ToolCall;
+use PhpLlm\LlmChain\Platform\Response\ToolCall;
 
 /**
  * @phpstan-type ToolCallData array{
@@ -25,9 +25,9 @@ final class TraceableToolbox implements ToolboxInterface
     ) {
     }
 
-    public function getMap(): array
+    public function getTools(): array
     {
-        return $this->toolbox->getMap();
+        return $this->toolbox->getTools();
     }
 
     public function execute(ToolCall $toolCall): mixed

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -8,10 +8,10 @@ use PhpLlm\LlmChain\Chain\StructuredOutput\ChainProcessor as StructureOutputProc
 use PhpLlm\LlmChain\Chain\StructuredOutput\ResponseFormatFactory;
 use PhpLlm\LlmChain\Chain\StructuredOutput\ResponseFormatFactoryInterface;
 use PhpLlm\LlmChain\Chain\Toolbox\ChainProcessor as ToolProcessor;
-use PhpLlm\LlmChain\Chain\Toolbox\MetadataFactory;
-use PhpLlm\LlmChain\Chain\Toolbox\MetadataFactory\ReflectionFactory;
 use PhpLlm\LlmChain\Chain\Toolbox\Toolbox;
 use PhpLlm\LlmChain\Chain\Toolbox\ToolboxInterface;
+use PhpLlm\LlmChain\Chain\Toolbox\ToolFactory\ReflectionToolFactory;
+use PhpLlm\LlmChain\Chain\Toolbox\ToolFactoryInterface;
 use PhpLlm\LlmChainBundle\Profiler\DataCollector;
 use PhpLlm\LlmChainBundle\Profiler\TraceableToolbox;
 
@@ -33,7 +33,7 @@ return static function (ContainerConfigurator $container): void {
             ->autowire()
             ->abstract()
             ->args([
-                '$metadataFactory' => service(MetadataFactory::class),
+                '$metadataFactory' => service(ToolFactoryInterface::class),
                 '$tools' => abstract_arg('Collection of tools'),
             ])
         ->set(Toolbox::class)
@@ -42,8 +42,8 @@ return static function (ContainerConfigurator $container): void {
                 '$tools' => tagged_iterator('llm_chain.tool'),
             ])
             ->alias(ToolboxInterface::class, Toolbox::class)
-        ->set(ReflectionFactory::class)
-            ->alias(MetadataFactory::class, ReflectionFactory::class)
+        ->set(ReflectionToolFactory::class)
+            ->alias(ToolFactoryInterface::class, ReflectionToolFactory::class)
         ->set('llm_chain.tool.chain_processor.abstract')
             ->class(ToolProcessor::class)
             ->abstract()

--- a/tests/Profiler/TraceableToolboxTest.php
+++ b/tests/Profiler/TraceableToolboxTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace PhpLlm\LlmChainBundle\Tests\Profiler;
 
-use PhpLlm\LlmChain\Chain\Toolbox\ExecutionReference;
-use PhpLlm\LlmChain\Chain\Toolbox\Metadata;
 use PhpLlm\LlmChain\Chain\Toolbox\ToolboxInterface;
-use PhpLlm\LlmChain\Model\Response\ToolCall;
+use PhpLlm\LlmChain\Platform\Response\ToolCall;
+use PhpLlm\LlmChain\Platform\Tool\ExecutionReference;
+use PhpLlm\LlmChain\Platform\Tool\Tool;
 use PhpLlm\LlmChainBundle\Profiler\TraceableToolbox;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
@@ -21,11 +21,11 @@ final class TraceableToolboxTest extends TestCase
     #[Test]
     public function getMap(): void
     {
-        $metadata = new Metadata(new ExecutionReference('Foo\Bar'), 'bar', 'description', null);
+        $metadata = new Tool(new ExecutionReference('Foo\Bar'), 'bar', 'description', null);
         $toolbox = $this->createToolbox(['tool' => $metadata]);
         $traceableToolbox = new TraceableToolbox($toolbox);
 
-        $map = $traceableToolbox->getMap();
+        $map = $traceableToolbox->getTools();
 
         self::assertSame(['tool' => $metadata], $map);
     }
@@ -33,7 +33,7 @@ final class TraceableToolboxTest extends TestCase
     #[Test]
     public function execute(): void
     {
-        $metadata = new Metadata(new ExecutionReference('Foo\Bar'), 'bar', 'description', null);
+        $metadata = new Tool(new ExecutionReference('Foo\Bar'), 'bar', 'description', null);
         $toolbox = $this->createToolbox(['tool' => $metadata]);
         $traceableToolbox = new TraceableToolbox($toolbox);
         $toolCall = new ToolCall('foo', '__invoke');
@@ -47,19 +47,19 @@ final class TraceableToolboxTest extends TestCase
     }
 
     /**
-     * @param Metadata[] $metadata
+     * @param Tool[] $tools
      */
-    private function createToolbox(array $metadata): ToolboxInterface
+    private function createToolbox(array $tools): ToolboxInterface
     {
-        return new class($metadata) implements ToolboxInterface {
+        return new class($tools) implements ToolboxInterface {
             public function __construct(
-                private readonly array $metadata,
+                private readonly array $tools,
             ) {
             }
 
-            public function getMap(): array
+            public function getTools(): array
             {
-                return $this->metadata;
+                return $this->tools;
             }
 
             public function execute(ToolCall $toolCall): string


### PR DESCRIPTION
Removing capability to injecting `LanguageModel` or `EmbeddingsModel` as service