### PR TITLE
fix(embedder)!: Use FQCN for embedder model config, to allow any Model child class

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -197,7 +197,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->arrayNode('model')
                                 ->children()
-                                    ->scalarNode('name')->isRequired()->end()
+                                    ->scalarNode('className')->isRequired()->end()
                                     ->scalarNode('version')->defaultNull()->end()
                                     ->arrayNode('options')
                                         ->scalarPrototype()->end()

--- a/src/DependencyInjection/LlmChainExtension.php
+++ b/src/DependencyInjection/LlmChainExtension.php
@@ -25,11 +25,9 @@ use PhpLlm\LlmChain\Platform\Bridge\Google\PlatformFactory as GooglePlatformFact
 use PhpLlm\LlmChain\Platform\Bridge\Meta\Llama;
 use PhpLlm\LlmChain\Platform\Bridge\Mistral\Mistral;
 use PhpLlm\LlmChain\Platform\Bridge\Mistral\PlatformFactory as MistralPlatformFactory;
-use PhpLlm\LlmChain\Platform\Bridge\OpenAI\Embeddings;
 use PhpLlm\LlmChain\Platform\Bridge\OpenAI\GPT;
 use PhpLlm\LlmChain\Platform\Bridge\OpenAI\PlatformFactory as OpenAIPlatformFactory;
 use PhpLlm\LlmChain\Platform\Bridge\OpenRouter\PlatformFactory as OpenRouterPlatformFactory;
-use PhpLlm\LlmChain\Platform\Bridge\Voyage\Voyage;
 use PhpLlm\LlmChain\Platform\Model;
 use PhpLlm\LlmChain\Platform\ModelClientInterface;
 use PhpLlm\LlmChain\Platform\Platform;
@@ -457,14 +455,13 @@ final class LlmChainExtension extends Extension
      */
     private function processEmbedderConfig(int|string $name, array $config, ContainerBuilder $container): void
     {
-        ['name' => $modelName, 'version' => $version, 'options' => $options] = $config['model'];
+        ['className' => $modelClassName, 'version' => $version, 'options' => $options] = $config['model'];
 
-        $modelClass = match (strtolower((string) $modelName)) {
-            'embeddings' => Embeddings::class,
-            'voyage' => Voyage::class,
-            default => throw new \InvalidArgumentException(sprintf('Model "%s" is not supported.', $modelName)),
-        };
-        $modelDefinition = (new Definition($modelClass));
+        if (!is_a($modelClassName, Model::class, true)) {
+            throw new \InvalidArgumentException(sprintf('"%s" class is not extending PhpLlm\LlmChain\Platform\Model.', $modelClassName));
+        }
+
+        $modelDefinition = (new Definition((string) $modelClassName));
         if (null !== $version) {
             $modelDefinition->setArgument('$name', $version);
         }


### PR DESCRIPTION
Ref: https://github.com/php-llm/llm-chain-bundle/issues/98

Before:

```yaml
llm_chain:
    embedder:
        default:
            platform: 'llm_chain.platform.mistral'
            model:
                name: 'Embeddings'
                version: 'mistral-embed'

```

After

```yaml
llm_chain:
    embedder:
        default:
            platform: 'llm_chain.platform.mistral'
            model:
                name: 'PhpLlm\LlmChain\Platform\Bridge\Mistral\Embeddings'
                version: 'mistral-embed'
```

This way, any class extending `PhpLlm\LlmChain\Platform\Model` can be used as embedder model, even one written by users themselves. This way, embeddings model of providers (OpenAI, Mistral, ...) can have the same class name.