### PR TITLE
Rename is_chain to is_agent configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ llm_chain:
                 - service: 'llm_chain.chain.research'
                   name: 'wikipedia_research'
                   description: 'Can research on Wikipedia'
-                  is_chain: true
+                  is_agent: true
         research:
             platform: 'llm_chain.platform.anthropic'
             model:

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -114,7 +114,7 @@ final class Configuration implements ConfigurationInterface
                                                 ->scalarNode('name')->end()
                                                 ->scalarNode('description')->end()
                                                 ->scalarNode('method')->end()
-                                                ->booleanNode('is_chain')->defaultFalse()->end()
+                                                ->booleanNode('is_agent')->defaultFalse()->end()
                                             ->end()
                                             ->beforeNormalization()
                                                 ->ifString()

--- a/src/DependencyInjection/LlmChainExtension.php
+++ b/src/DependencyInjection/LlmChainExtension.php
@@ -292,7 +292,7 @@ final class LlmChainExtension extends Extension
                     $reference = new Reference($tool['service']);
                     // We use the memory factory in case method, description and name are set
                     if (isset($tool['name'], $tool['description'])) {
-                        if ($tool['is_chain']) {
+                        if ($tool['is_agent']) {
                             $chainWrapperDefinition = new Definition(ChainTool::class, ['$chain' => $reference]);
                             $container->setDefinition('llm_chain.toolbox.'.$name.'.chain_wrapper.'.$tool['name'], $chainWrapperDefinition);
                             $reference = new Reference('llm_chain.toolbox.'.$name.'.chain_wrapper.'.$tool['name']);


### PR DESCRIPTION
## Summary
- Renamed `is_chain` configuration option to `is_agent` for better clarity
- Updated all occurrences in Configuration.php, LlmChainExtension.php, and README.md
- This better reflects the actual purpose when referencing chain services as tools that act as agents

## Test plan
- [x] Configuration schema updated
- [x] Service processing logic updated  
- [x] Documentation updated
- [ ] Manual testing with a chain configured as agent tool

🤖 Generated with [Claude Code](https://claude.ai/code)